### PR TITLE
Default to dev db in application.properties

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.profiles.active=prod
+spring.profiles.active=dev
 
 spring.data.rest.base-path=/api
 


### PR DESCRIPTION
Was defaulting to prod db which, if people follow the set up instructions, doesn't yet exist.

It's possible to specify another active profile when booting the application.

For example:
`mvn spring-boot:run -Dspring-boot.run.profiles=prod`