### PR TITLE
[upgrade dependency] Upgrade Lombok to minimum version that works on jdk21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-	    <version>1.18.24</version>
+	    <version>1.18.30</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
As per good old stackoverflow https://stackoverflow.com/a/77171271 Older versions aren't compatiable as they throw

Fatal error compiling: java.lang.NoSuchFieldError: Class com.sun.tools.javac.tree.JCTree$JCImport does not have member field 'com.sun.tools.javac.tree.JCTree qualid'

This works with jdk17 too